### PR TITLE
PyTorch Lightning & Jupyter Compatibility

### DIFF
--- a/ivon/_ivon.py
+++ b/ivon/_ivon.py
@@ -128,8 +128,10 @@ class IVON(torch.optim.Optimizer):
     @contextmanager
     def sampled_params(self, train: bool = False):
         param_avg, noise = self._sample_params()
-        yield
-        self._restore_param_average(train, param_avg, noise)
+        try:
+            yield
+        finally:
+            self._restore_param_average(train, param_avg, noise)
 
     def _restore_param_average(
         self, train: bool, param_avg: Tensor, noise: Tensor

--- a/ivon/_ivon.py
+++ b/ivon/_ivon.py
@@ -174,7 +174,8 @@ class IVON(torch.optim.Optimizer):
             losses = []
             for _ in range(self.mc_samples):
                 with torch.enable_grad():
-                    loss = closure()
+                    with self.sampled_params():
+                        loss = closure()
                 losses.append(loss)
             loss = sum(losses) / self.mc_samples
         if self.sync and dist.is_initialized():  # explicit sync

--- a/ivon/_ivon.py
+++ b/ivon/_ivon.py
@@ -238,6 +238,12 @@ class IVON(torch.optim.Optimizer):
 
         offset = 0
         for group in self.param_groups:
+            for p in group["params"]:
+                if p is None:
+                    continue
+                group_device = p.device
+                break
+
             lr = group["lr"]
             b1 = group["beta1"]
             b2 = group["beta2"]
@@ -246,6 +252,8 @@ class IVON(torch.optim.Optimizer):
             param_avg = torch.cat(
                 [p.flatten() for p in group["params"] if p is not None], 0
             )
+
+            group["momentum"] = group["momentum"].to(group_device)
 
             group["momentum"] = self._new_momentum(
                 self.state["avg_grad"][pg_slice], group["momentum"], b1

--- a/ivon/_ivon.py
+++ b/ivon/_ivon.py
@@ -198,8 +198,17 @@ class IVON(torch.optim.Optimizer):
         offset = 0
         for group in self.param_groups:
             gnumel = group["numel"]
+
+            for p in group["params"]:
+                if p is None:
+                    continue
+                group_device = p.device
+                break
+
+            group["hess"] = group["hess"].to(group_device)
+
             noise_sample = (
-                torch.randn(gnumel, device=self._device, dtype=self._dtype)
+                torch.randn(gnumel, device=group_device, dtype=self._dtype)
                 / (
                     group["ess"] * (group["hess"] + group["weight_decay"])
                 ).sqrt()

--- a/ivon/_ivon.py
+++ b/ivon/_ivon.py
@@ -174,7 +174,7 @@ class IVON(torch.optim.Optimizer):
             losses = []
             for _ in range(self.mc_samples):
                 with torch.enable_grad():
-                    with self.sampled_params():
+                    with self.sampled_params(train=True):
                         loss = closure()
                 losses.append(loss)
             loss = sum(losses) / self.mc_samples


### PR DESCRIPTION
This PR introduces three changes:

- Find the device of each parameter group on demand, instead of at initialization time. This is needed for compatibility with PyTorch lightning, which moves the model to the device only after the optimizer has been created. It also allows to use a different device per parameter group.
- Evaluate the `step` closure inside of the `with self.sampled_params(train=True)` context manager. PT lightning requires this as it uses the closure. This change also brings the implementation more in line with the PT documentation, which says that the closure should only evaluate the model and compute gradients.
- Wrap the `yield` in the `sampled_params` generator with try-finally, so that the parameter average gets restored even if the parent function caused an exception. This useful for Jupyter notebooks, where crashing cells can otherwise leave the optimizer in an inconsistent state.

I've been using this fork for the past few weeks, so it's at least somewhat tested. Please let me know if you'd like me to change anything.